### PR TITLE
Introduce "body" directive to decode HTTP request body

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,14 @@ func ListUsers(rw http.ResponseWriter, r *http.Request) {
 - [x] Decode a field from multiple sources, e.g. both query and headers, `in:"form=access_token;header=x-api-token"`
 - [x] Register custom type decoders by implementing `httpin.Decoder` interface
 - [x] Compose an input struct by embedding struct fields
-- [x] Builtin directive `required` to tag a field as **required**
+- [x] Builtin directive `required` to tag a field as required
+- [x] Builtin directive `body` to parse HTTP request body as `JSON` or `XML`
 - [x] Register custom directive executors to extend the ability of field resolving, see directive [required](./required.go) as an example and think about implementing your own directives like `trim`, `to_lowercase`, `base58_to_int`, etc.
 - [x] Easily integrating with popular Go web frameworks and packages
 
-## Sample User Defined Input Structs
+## Example (Use http.Handler)
+
+First, set up the middleware for your handlers (**bind Input vs. Handler**). We recommend using [alice](https://github.com/justinas/alice) to chain your HTTP middleware functions.
 
 ```go
 type Authorization struct {
@@ -94,13 +97,7 @@ type ListUsersInput struct {
 	Pagination    // Embedded field works
 	Authorization // Embedded field works
 }
-```
 
-## Integrate with Go Native http.Handler (Use Middleware)
-
-First, set up the middleware for your handlers (**bind Input vs. Handler**). We recommend using [alice](https://github.com/justinas/alice) to chain your HTTP middleware functions.
-
-```go
 func init() {
 	http.Handle("/users", alice.New(
 		httpin.NewInput(ListUsersInput{}),
@@ -118,12 +115,47 @@ func ListUsers(rw http.ResponseWriter, r *http.Request) {
 }
 ```
 
-## Integrate with Popular Go Web Frameworks and Components
+## Integrate with Popular Go Web Frameworks and Packages
 
 - [gin-gonic/gin](https://github.com/ggicci/httpin/wiki/Integrate-with-gin)
 - [go-chi/chi](https://github.com/ggicci/httpin/wiki/Integrate-with-gochi)
 - [gorilla/mux](https://github.com/ggicci/httpin/wiki/Integrate-with-gorilla-mux)
 - ...
+
+## Parse HTTP Request Body
+
+There're two ways of parsing HTTP request body into your input struct.
+
+### Parse HTTP request body into the input struct (body -> input)
+
+Embed one of our _body decoder annotations_ into your input struct:
+
+```go
+// POST /users with JSON body
+type CreateUserInput struct {
+	httpin.JSONBody        // annotation
+	Username        string `json:"username"`
+	Gender          int    `json:"gender"`
+}
+```
+
+- `httpin.JSONBody`: parse request body in JSON format
+- `httpin.XMLBody`: parse request body in XML format
+
+### Parse HTTP request body into a field of the input struct (body -> input.field)
+
+Use `body` directive.
+
+```go
+// PATCH /users/:uid with JSON body
+type UpdateUserProfileInput struct {
+	UserID int64 `in:"path=uid"` // get user id from path variable
+	Patch  struct {
+		Username string `json:"username"`
+		Gender   int    `json:"gender"`
+	} `in:"body=json"` // use body=xml to decode in XML format
+}
+```
 
 ## Advanced
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ var MyLowercaseDirectiveExecutor = httpin.DirectiveExecutorFunc(toLower)
 Seconds, register it to `httpin`:
 
 ```go
-httpin.RegisterDirectiveExecutor("to_lowercase", MyLowercaseDirectiveExecutor)
+httpin.RegisterDirectiveExecutor("to_lowercase", MyLowercaseDirectiveExecutor, nil)
 ```
 
 Finally, you can use your own directives in the struct tags:

--- a/body.go
+++ b/body.go
@@ -3,17 +3,66 @@ package httpin
 import (
 	"encoding/json"
 	"encoding/xml"
+	"fmt"
 	"net/http"
 	"reflect"
+	"strings"
 )
 
 type JSONBody struct{}
 type XMLBody struct{}
 
 var (
-	typeJSONBody = reflect.TypeOf(JSONBody{})
-	typeXMLBody  = reflect.TypeOf(XMLBody{})
+	bodyTypeAnnotationJSON = reflect.TypeOf(JSONBody{})
+	bodyTypeAnnotationXML  = reflect.TypeOf(XMLBody{})
 )
+
+const (
+	bodyTypeJSON = "json"
+	bodyTypeXML  = "xml"
+)
+
+func bodyDirectiveNormalizer(dir *Directive) error {
+	if len(dir.Argv) == 0 {
+		dir.Argv = []string{bodyTypeJSON}
+	}
+	dir.Argv[0] = strings.ToLower(dir.Argv[0])
+
+	var bodyType = dir.Argv[0]
+	if bodyType != bodyTypeJSON && bodyType != bodyTypeXML {
+		return fmt.Errorf("%w: %q", ErrUnknownBodyType, bodyType)
+	}
+
+	return nil
+}
+
+func bodyTypeString(bodyType reflect.Type) string {
+	switch bodyType {
+	case bodyTypeAnnotationJSON:
+		return bodyTypeJSON
+	case bodyTypeAnnotationXML:
+		return bodyTypeXML
+	default:
+		panic(ErrUnknownBodyType)
+	}
+}
+
+func bodyDecoder(ctx *DirectiveContext) error {
+	var err = ErrUnknownBodyType
+	switch ctx.Argv[0] { // body type
+	case bodyTypeJSON:
+		err = decodeJSONBody(ctx.Request, ctx.Value)
+	case bodyTypeXML:
+		err = decodeXMLBody(ctx.Request, ctx.Value)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	ctx.DeliverContextValue(StopRecursion, true)
+	return nil
+}
 
 func decodeJSONBody(req *http.Request, rv reflect.Value) error {
 	obj := rv.Interface()

--- a/body.go
+++ b/body.go
@@ -1,6 +1,26 @@
 package httpin
 
-func bodyDecoder(ctx *DirectiveContext) error {
-	// TODO(ggicci): implement this
-	return nil
+import (
+	"encoding/json"
+	"encoding/xml"
+	"net/http"
+	"reflect"
+)
+
+type JSONBody struct{}
+type XMLBody struct{}
+
+var (
+	typeJSONBody = reflect.TypeOf(JSONBody{})
+	typeXMLBody  = reflect.TypeOf(XMLBody{})
+)
+
+func decodeJSONBody(req *http.Request, rv reflect.Value) error {
+	obj := rv.Interface()
+	return json.NewDecoder(req.Body).Decode(&obj)
+}
+
+func decodeXMLBody(req *http.Request, rv reflect.Value) error {
+	obj := rv.Interface()
+	return xml.NewDecoder(req.Body).Decode(&obj)
 }

--- a/body_test.go
+++ b/body_test.go
@@ -1,8 +1,10 @@
 package httpin
 
 import (
+	"errors"
 	"io"
 	"net/http"
+	"net/url"
 	"reflect"
 	"strings"
 	"testing"
@@ -23,19 +25,105 @@ type BodyPayload struct {
 	Languages []*LanguageLevel `json:"languages" xml:"languages"`
 }
 
-type JSONBodyPayload struct {
+type JSONBodyPayloadWithAnnotation struct {
 	JSONBody
 	BodyPayload
 }
 
-type XMLBodyPayload struct {
+type XMLBodyPayloadWithAnnotation struct {
 	XMLBody
 	BodyPayload
 }
 
+type JSONBodyPayloadWithBodyDirective struct {
+	Page     int          `in:"form=page"`
+	PageSize int          `in:"form=page_size"`
+	Body     *BodyPayload `in:"body=json"`
+}
+
+type ThingWithDuplicateAnnotations struct {
+	JSONBody
+	XMLBody
+	Page int `in:"form=page"`
+}
+
+type ThingWithInvalidBodyType struct {
+	Username string `in:"form=username"`
+
+	Patch map[string]interface{} `in:"body=yaml"`
+}
+
+type ThingWithEmptyBodyType struct {
+	Username string `in:"form=username"`
+
+	Patch map[string]interface{} `in:"body"`
+}
+
+func TestAnnotationField(t *testing.T) {
+	Convey("annotate: duplicate annotations", t, func() {
+		resolver, err := buildResolverTree(reflect.TypeOf(ThingWithDuplicateAnnotations{}))
+		So(resolver, ShouldBeNil)
+		So(err, ShouldBeError)
+		So(errors.Is(err, ErrDuplicateAnnotationField), ShouldBeTrue)
+	})
+}
+
+func TestNormalizeBodyDirective(t *testing.T) {
+	Convey("body directive: empty body type defaults to json", t, func() {
+		resolver, err := buildResolverTree(reflect.TypeOf(ThingWithEmptyBodyType{}))
+		So(err, ShouldBeNil)
+		So(resolver.Fields[1].Directives[0].Argv[0], ShouldEqual, "json")
+	})
+
+	Convey("body directive: unknown body type", t, func() {
+		resolver, err := buildResolverTree(reflect.TypeOf(ThingWithInvalidBodyType{}))
+		So(resolver, ShouldBeNil)
+		So(err, ShouldBeError)
+		So(errors.Is(err, ErrUnknownBodyType), ShouldBeTrue)
+	})
+}
+
 func TestJSONBody(t *testing.T) {
-	Convey("json: parse HTTP body in JSON", t, func() {
-		resolver, err := buildResolverTree(reflect.TypeOf(JSONBodyPayload{}))
+	Convey("body: parse HTTP body (in JSON) into a field of the input struct", t, func() {
+		resolver, err := buildResolverTree(reflect.TypeOf(JSONBodyPayloadWithBodyDirective{}))
+		So(err, ShouldBeNil)
+		So(resolver, ShouldNotBeNil)
+		r, _ := http.NewRequest("GET", "https://example.com", nil)
+
+		r.Form = make(url.Values)
+		r.Form.Set("page", "4")
+		r.Form.Set("page_size", "30")
+		r.Body = io.NopCloser(strings.NewReader(`{
+			"name": "Elia",
+			"is_native": false,
+			"age": 14,
+			"hobbies": ["Gaming", "Drawing"],
+			"languages": [
+				{"lang": "English", "level": 10},
+				{"lang": "Japanese", "level": 3}
+			]
+		}`))
+
+		res, err := resolver.resolve(r)
+		So(err, ShouldBeNil)
+		So(res.Interface(), ShouldResemble, &JSONBodyPayloadWithBodyDirective{
+			Page:     4,
+			PageSize: 30,
+			Body: &BodyPayload{
+				Name:     "Elia",
+				Age:      14,
+				IsNative: false,
+				Hobbies:  []string{"Gaming", "Drawing"},
+				Languages: []*LanguageLevel{
+					{"English", 10},
+					{"Japanese", 3},
+				},
+			},
+		})
+	})
+
+	Convey("body: parse HTTP body (in JSON) to the input struct, use annotation", t, func() {
+		resolver, err := buildResolverTree(reflect.TypeOf(JSONBodyPayloadWithAnnotation{}))
 		So(err, ShouldBeNil)
 		So(resolver, ShouldNotBeNil)
 		r, _ := http.NewRequest("GET", "https://example.com", nil)
@@ -52,7 +140,7 @@ func TestJSONBody(t *testing.T) {
 		}`))
 		res, err := resolver.resolve(r)
 		So(err, ShouldBeNil)
-		So(res.Interface(), ShouldResemble, &JSONBodyPayload{
+		So(res.Interface(), ShouldResemble, &JSONBodyPayloadWithAnnotation{
 			BodyPayload: BodyPayload{
 				Name:     "Elia",
 				Age:      14,
@@ -68,8 +156,8 @@ func TestJSONBody(t *testing.T) {
 }
 
 func TestXMLBody(t *testing.T) {
-	Convey("json: parse HTTP body in XML", t, func() {
-		resolver, err := buildResolverTree(reflect.TypeOf(XMLBodyPayload{}))
+	Convey("body: parse HTTP body (in XML) to the input struct, use annotation", t, func() {
+		resolver, err := buildResolverTree(reflect.TypeOf(XMLBodyPayloadWithAnnotation{}))
 		So(err, ShouldBeNil)
 		So(resolver, ShouldNotBeNil)
 		r, _ := http.NewRequest("GET", "https://example.com", nil)
@@ -91,7 +179,7 @@ func TestXMLBody(t *testing.T) {
 	 </BodyPayload>`))
 		res, err := resolver.resolve(r)
 		So(err, ShouldBeNil)
-		So(res.Interface(), ShouldResemble, &XMLBodyPayload{
+		So(res.Interface(), ShouldResemble, &XMLBodyPayloadWithAnnotation{
 			BodyPayload: BodyPayload{
 				Name:     "Elia",
 				Age:      14,
@@ -103,5 +191,27 @@ func TestXMLBody(t *testing.T) {
 				},
 			},
 		})
+	})
+}
+
+func TestBodyDecoderDecodeFailed(t *testing.T) {
+	Convey("body: parse request body in JSON failed", t, func() {
+		resolver, err := buildResolverTree(reflect.TypeOf(JSONBodyPayloadWithAnnotation{}))
+		So(err, ShouldBeNil)
+		So(resolver, ShouldNotBeNil)
+		r, _ := http.NewRequest("GET", "https://example.com", nil)
+
+		r.Body = io.NopCloser(strings.NewReader(`{"name": "Elia"`))
+		_, err = resolver.resolve(r)
+		So(err, ShouldBeError)
+	})
+}
+
+func Test_bodyTypeString(t *testing.T) {
+	Convey("bodyTypeString should panic on unknown body type", t, func() {
+		type yamlBody struct{}
+		So(func() {
+			bodyTypeString(reflect.TypeOf(yamlBody{}))
+		}, ShouldPanic)
 	})
 }

--- a/body_test.go
+++ b/body_test.go
@@ -1,1 +1,107 @@
 package httpin
+
+import (
+	"io"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+type LanguageLevel struct {
+	Language string `json:"lang" xml:"lang"`
+	Level    int    `json:"level" xml:"level"`
+}
+
+type BodyPayload struct {
+	Name      string           `json:"name" xml:"name"`
+	Age       int              `json:"age" xml:"age"`
+	IsNative  bool             `json:"is_native" xml:"is_native"`
+	Hobbies   []string         `json:"hobbies" xml:"hobbies"`
+	Languages []*LanguageLevel `json:"languages" xml:"languages"`
+}
+
+type JSONBodyPayload struct {
+	JSONBody
+	BodyPayload
+}
+
+type XMLBodyPayload struct {
+	XMLBody
+	BodyPayload
+}
+
+func TestJSONBody(t *testing.T) {
+	Convey("json: parse HTTP body in JSON", t, func() {
+		resolver, err := buildResolverTree(reflect.TypeOf(JSONBodyPayload{}))
+		So(err, ShouldBeNil)
+		So(resolver, ShouldNotBeNil)
+		r, _ := http.NewRequest("GET", "https://example.com", nil)
+
+		r.Body = io.NopCloser(strings.NewReader(`{
+			"name": "Elia",
+			"is_native": false,
+			"age": 14,
+			"hobbies": ["Gaming", "Drawing"],
+			"languages": [
+				{"lang": "English", "level": 10},
+				{"lang": "Japanese", "level": 3}
+			]
+		}`))
+		res, err := resolver.resolve(r)
+		So(err, ShouldBeNil)
+		So(res.Interface(), ShouldResemble, &JSONBodyPayload{
+			BodyPayload: BodyPayload{
+				Name:     "Elia",
+				Age:      14,
+				IsNative: false,
+				Hobbies:  []string{"Gaming", "Drawing"},
+				Languages: []*LanguageLevel{
+					{"English", 10},
+					{"Japanese", 3},
+				},
+			},
+		})
+	})
+}
+
+func TestXMLBody(t *testing.T) {
+	Convey("json: parse HTTP body in XML", t, func() {
+		resolver, err := buildResolverTree(reflect.TypeOf(XMLBodyPayload{}))
+		So(err, ShouldBeNil)
+		So(resolver, ShouldNotBeNil)
+		r, _ := http.NewRequest("GET", "https://example.com", nil)
+
+		r.Body = io.NopCloser(strings.NewReader(`<BodyPayload>
+		<name>Elia</name>
+		<age>14</age>
+		<is_native>false</is_native>
+		<hobbies>Gaming</hobbies>
+		<hobbies>Drawing</hobbies>
+		<languages>
+		   <lang>English</lang>
+		   <level>10</level>
+		</languages>
+		<languages>
+		   <lang>Japanese</lang>
+		   <level>3</level>
+		</languages>
+	 </BodyPayload>`))
+		res, err := resolver.resolve(r)
+		So(err, ShouldBeNil)
+		So(res.Interface(), ShouldResemble, &XMLBodyPayload{
+			BodyPayload: BodyPayload{
+				Name:     "Elia",
+				Age:      14,
+				IsNative: false,
+				Hobbies:  []string{"Gaming", "Drawing"},
+				Languages: []*LanguageLevel{
+					{"English", 10},
+					{"Japanese", 3},
+				},
+			},
+		})
+	})
+}

--- a/directives.go
+++ b/directives.go
@@ -17,7 +17,6 @@ func init() {
 
 	RegisterDirectiveExecutor("form", DirectiveExecutorFunc(formValueExtractor))
 	RegisterDirectiveExecutor("header", DirectiveExecutorFunc(headerValueExtractor))
-	RegisterDirectiveExecutor("body", DirectiveExecutorFunc(bodyDecoder))
 	RegisterDirectiveExecutor("required", DirectiveExecutorFunc(required))
 }
 

--- a/directives.go
+++ b/directives.go
@@ -9,15 +9,23 @@ import (
 )
 
 var (
-	executors map[string]DirectiveExecutor
+	executors   map[string]DirectiveExecutor
+	normalizers map[string]DirectiveNormalizer
 )
 
 func init() {
 	executors = make(map[string]DirectiveExecutor)
+	normalizers = make(map[string]DirectiveNormalizer)
 
-	RegisterDirectiveExecutor("form", DirectiveExecutorFunc(formValueExtractor))
-	RegisterDirectiveExecutor("header", DirectiveExecutorFunc(headerValueExtractor))
-	RegisterDirectiveExecutor("required", DirectiveExecutorFunc(required))
+	// Built-in Directives
+	RegisterDirectiveExecutor("form", DirectiveExecutorFunc(formValueExtractor), nil)
+	RegisterDirectiveExecutor("header", DirectiveExecutorFunc(headerValueExtractor), nil)
+	RegisterDirectiveExecutor(
+		"body",
+		DirectiveExecutorFunc(bodyDecoder),
+		DirectiveNormalizerFunc(bodyDirectiveNormalizer),
+	)
+	RegisterDirectiveExecutor("required", DirectiveExecutorFunc(required), nil)
 }
 
 // DirectiveExecutor is the interface implemented by a "directive executor".
@@ -25,23 +33,28 @@ type DirectiveExecutor interface {
 	Execute(*DirectiveContext) error
 }
 
+type DirectiveNormalizer interface {
+	Normalize(*Directive) error
+}
+
 // RegisterDirectiveExecutor registers a named executor globally, which
 // implemented the DirectiveExecutor interface. Will panic if the name were
 // taken or nil executor.
-func RegisterDirectiveExecutor(name string, exe DirectiveExecutor) {
+func RegisterDirectiveExecutor(name string, exe DirectiveExecutor, norm DirectiveNormalizer) {
 	if _, ok := executors[name]; ok {
 		panic(fmt.Errorf("%w: %q", ErrDuplicateExecutor, name))
 	}
-	ReplaceDirectiveExecutor(name, exe)
+	ReplaceDirectiveExecutor(name, exe, norm)
 }
 
 // ReplaceDirectiveExecutor works like RegisterDirectiveExecutor without panic
 // on duplicate names.
-func ReplaceDirectiveExecutor(name string, exe DirectiveExecutor) {
+func ReplaceDirectiveExecutor(name string, exe DirectiveExecutor, norm DirectiveNormalizer) {
 	if exe == nil {
 		panic(fmt.Errorf("%w: %q", ErrNilExecutor, name))
 	}
 	executors[name] = exe
+	normalizers[name] = norm
 }
 
 // DirectiveExecutorFunc is an adpator to allow to use of ordinary functions as
@@ -53,10 +66,19 @@ func (f DirectiveExecutorFunc) Execute(ctx *DirectiveContext) error {
 	return f(ctx)
 }
 
+// DirectiveNormalizerFunc is an adaptor to allow to use of ordinary functions as
+// httpin.DirectiveNormalizer.
+type DirectiveNormalizerFunc func(*Directive) error
+
+// Normalize calls f(dir).
+func (f DirectiveNormalizerFunc) Normalize(dir *Directive) error {
+	return f(dir)
+}
+
 // DirectiveContext holds essential information about the field being resolved
 // and the active HTTP request. Working as the context in a directive executor.
 type DirectiveContext struct {
-	directive
+	Directive
 	ValueType reflect.Type
 	Value     reflect.Value
 	Request   *http.Request
@@ -69,9 +91,9 @@ func (c *DirectiveContext) DeliverContextValue(key, value interface{}) {
 	c.Context = context.WithValue(c.Context, key, value)
 }
 
-// directive defines the profile to locate an httpin.DirectiveExecutor instance
+// Directive defines the profile to locate an httpin.DirectiveExecutor instance
 // and drive it with essential arguments.
-type directive struct {
+type Directive struct {
 	Executor string   // name of the executor
 	Argv     []string // argv
 }
@@ -82,7 +104,7 @@ type directive struct {
 // Example directives are:
 //    "form=page,page_index" -> { Executor: "form", Args: ["page", "page_index"] }
 //    "header=x-api-token"   -> { Executor: "header", Args: ["x-api-token"] }
-func buildDirective(directiveStr string) (*directive, error) {
+func buildDirective(directiveStr string) (*Directive, error) {
 	parts := strings.SplitN(directiveStr, "=", 2)
 	executor := parts[0]
 	var argv []string
@@ -92,20 +114,33 @@ func buildDirective(directiveStr string) (*directive, error) {
 	}
 
 	// Ensure that the corresponding executor had been registered.
-	dir := &directive{Executor: executor, Argv: argv}
+	dir := &Directive{Executor: executor, Argv: argv}
 	if dir.getExecutor() == nil {
 		return nil, fmt.Errorf("%w: %q", ErrUnregisteredExecutor, dir.Executor)
+	}
+
+	// Normalize the directive.
+	norm := dir.getNormalizer()
+	if norm != nil {
+		if err := norm.Normalize(dir); err != nil {
+			return nil, fmt.Errorf("invalid directive %q: %w", dir.Executor, err)
+		}
 	}
 
 	return dir, nil
 }
 
 // Execute locates the executor and runs it with the specified context.
-func (d *directive) Execute(ctx *DirectiveContext) error {
+func (d *Directive) Execute(ctx *DirectiveContext) error {
 	return d.getExecutor().Execute(ctx)
 }
 
 // getExecutor locates the executor by its name. It must exist.
-func (d *directive) getExecutor() DirectiveExecutor {
+func (d *Directive) getExecutor() DirectiveExecutor {
 	return executors[d.Executor]
+}
+
+// getNormalizer locates the directive normalizer by its name.
+func (d *Directive) getNormalizer() DirectiveNormalizer {
+	return normalizers[d.Executor]
 }

--- a/directives_test.go
+++ b/directives_test.go
@@ -14,16 +14,16 @@ func (d *NoopDirective) Execute(ctx *DirectiveContext) error {
 
 func TestDirectives(t *testing.T) {
 	Convey("Register duplicate executor", t, func() {
-		So(func() { RegisterDirectiveExecutor("noop", &NoopDirective{}) }, ShouldNotPanic)
-		So(func() { RegisterDirectiveExecutor("noop", &NoopDirective{}) }, ShouldPanic)
+		So(func() { RegisterDirectiveExecutor("noop", &NoopDirective{}, nil) }, ShouldNotPanic)
+		So(func() { RegisterDirectiveExecutor("noop", &NoopDirective{}, nil) }, ShouldPanic)
 	})
 
 	Convey("Register nil executor", t, func() {
-		So(func() { RegisterDirectiveExecutor("whatever", nil) }, ShouldPanic)
+		So(func() { RegisterDirectiveExecutor("whatever", nil, nil) }, ShouldPanic)
 	})
 
 	Convey("Replace an executor", t, func() {
-		So(func() { ReplaceDirectiveExecutor("noop", &NoopDirective{}) }, ShouldNotPanic)
-		So(func() { ReplaceDirectiveExecutor("noop", &NoopDirective{}) }, ShouldNotPanic)
+		So(func() { ReplaceDirectiveExecutor("noop", &NoopDirective{}, nil) }, ShouldNotPanic)
+		So(func() { ReplaceDirectiveExecutor("noop", &NoopDirective{}, nil) }, ShouldNotPanic)
 	})
 }

--- a/errors.go
+++ b/errors.go
@@ -7,13 +7,15 @@ import (
 )
 
 var (
-	ErrMissingField         = errors.New("missing required field")
-	ErrUnsupporetedType     = errors.New("unsupported type")
-	ErrUnregisteredExecutor = errors.New("unregistered executor")
-	ErrDuplicateTypeDecoder = errors.New("duplicate type decoder")
-	ErrNilTypeDecoder       = errors.New("nil type decoder")
-	ErrDuplicateExecutor    = errors.New("duplicate executor")
-	ErrNilExecutor          = errors.New("nil executor")
+	ErrMissingField             = errors.New("missing required field")
+	ErrUnsupporetedType         = errors.New("unsupported type")
+	ErrUnregisteredExecutor     = errors.New("unregistered executor")
+	ErrDuplicateTypeDecoder     = errors.New("duplicate type decoder")
+	ErrNilTypeDecoder           = errors.New("nil type decoder")
+	ErrDuplicateExecutor        = errors.New("duplicate executor")
+	ErrNilExecutor              = errors.New("nil executor")
+	ErrUnknownBodyType          = errors.New("unknown body type")
+	ErrDuplicateAnnotationField = errors.New("duplicate annotation field")
 )
 
 type UnsupportedTypeError struct {

--- a/extractor.go
+++ b/extractor.go
@@ -7,7 +7,7 @@ import (
 )
 
 func extractFromKVS(ctx *DirectiveContext, kvs map[string][]string, isHeaderKey bool) error {
-	for _, key := range ctx.directive.Argv {
+	for _, key := range ctx.Directive.Argv {
 		if isHeaderKey {
 			key = http.CanonicalHeaderKey(key)
 		}

--- a/gochi.go
+++ b/gochi.go
@@ -8,7 +8,7 @@ import "net/http"
 type GochiURLParamFunc func(r *http.Request, key string) string
 
 func UseGochiURLParam(executor string, fn GochiURLParamFunc) {
-	RegisterDirectiveExecutor(executor, &gochiURLParamExtractor{URLParam: fn})
+	RegisterDirectiveExecutor(executor, &gochiURLParamExtractor{URLParam: fn}, nil)
 }
 
 type gochiURLParamExtractor struct {

--- a/gochi_test.go
+++ b/gochi_test.go
@@ -10,13 +10,13 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-type GetPostOfUserV2Input struct {
-	Username string `in:"gochi=username"`
-	PostID   int64  `in:"gochi=pid"`
+type GetArticleOfUserInput struct {
+	Author    string `in:"gochi=author"` // equivalent to chi.URLParam("author")
+	ArticleID int64  `in:"gochi=articleID"`
 }
 
-func GetPostOfUserV2Handler(rw http.ResponseWriter, r *http.Request) {
-	var input = r.Context().Value(Input).(*GetPostOfUserV2Input)
+func GetArticleOfUser(rw http.ResponseWriter, r *http.Request) {
+	var input = r.Context().Value(Input).(*GetArticleOfUserInput)
 	json.NewEncoder(rw).Encode(input)
 }
 
@@ -25,17 +25,17 @@ func TestGochiURLParam(t *testing.T) {
 
 	Convey("Gochi: can extract URLParam", t, func() {
 		rw := httptest.NewRecorder()
-		r, err := http.NewRequest("GET", "/ggicci/posts/1024", nil)
+		r, err := http.NewRequest("GET", "/ggicci/articles/1024", nil)
 		So(err, ShouldBeNil)
 
 		router := chi.NewRouter()
 		router.With(
-			NewInput(GetPostOfUserV2Input{}),
-		).Get("/{username}/posts/{pid}", GetPostOfUserV2Handler)
+			NewInput(GetArticleOfUserInput{}),
+		).Get("/{author}/articles/{articleID}", GetArticleOfUser)
 
 		router.ServeHTTP(rw, r)
 		So(rw.Code, ShouldEqual, 200)
-		expected := `{"Username":"ggicci","PostID":1024}` + "\n"
+		expected := `{"Author":"ggicci","ArticleID":1024}` + "\n"
 		So(rw.Body.String(), ShouldEqual, expected)
 	})
 }

--- a/gorilla.go
+++ b/gorilla.go
@@ -18,7 +18,7 @@ type GorillaMuxVarsFunc func(*http.Request) map[string]string
 //       UserID `httpin:"path=user_id"`
 //    }
 func UseGorillaMux(executor string, fnVars GorillaMuxVarsFunc) {
-	RegisterDirectiveExecutor(executor, &gorillaMuxVarsExtractor{Vars: fnVars})
+	RegisterDirectiveExecutor(executor, &gorillaMuxVarsExtractor{Vars: fnVars}, nil)
 }
 
 type gorillaMuxVarsExtractor struct {

--- a/httpin.go
+++ b/httpin.go
@@ -16,6 +16,8 @@ const (
 	// When multiple executors were applied to a field, if the field value were set by
 	// an executor, the latter executors may skip running by consulting this context value.
 	FieldSet
+
+	StopRecursion
 )
 
 var builtEngines sync.Map

--- a/httpin_test.go
+++ b/httpin_test.go
@@ -59,8 +59,6 @@ type ProductQuery struct {
 	SortDesc  []bool    `in:"form=sort_desc"`
 	Pagination
 	Authorization
-
-	Patch map[string]interface{} `in:"body=json"`
 }
 
 type ObjectID struct {


### PR DESCRIPTION
Use `body` directive:

1. Use *annotations*, parse HTTP request body to input (body -> input)

```go
// POST /users with JSON body
type CreateUserInput struct {
	httpin.JSONBody        // annotation
	Username        string `json:"username"`
	Gender          int    `json:"gender"`
}
```

2. Declare `body` directive, parse HTTP request body to input struct field (body -> input.field)

```go
// PATCH /users/:uid with JSON body
type UpdateUserProfileInput struct {
	UserID int64 `in:"path=uid"` // get user id from path variable
	Patch  struct {
		Username string `json:"username"`
		Gender   int    `json:"gender"`
	} `in:"body=json"` // use body=xml to decode in XML format
}
```