### PR TITLE
GH-8 update resolver required field error message to use directive keys

### DIFF
--- a/chain_test.go
+++ b/chain_test.go
@@ -59,7 +59,7 @@ func TestChain(t *testing.T) {
 		So(rw.Code, ShouldEqual, 400)
 		var out map[string]interface{}
 		So(json.NewDecoder(rw.Body).Decode(&out), ShouldBeNil)
-		So(out["field"], ShouldEqual, "Token")
+		So(out["field"], ShouldEqual, "form:access_token|header:x-api-key")
 		So(out["source"], ShouldEqual, "required")
 		So(out["error"], ShouldEqual, ErrMissingField.Error())
 	})

--- a/httpin_test.go
+++ b/httpin_test.go
@@ -332,7 +332,7 @@ func TestEngine(t *testing.T) {
 		So(err, ShouldBeError)
 		var invalidField *InvalidFieldError
 		So(errors.As(err, &invalidField), ShouldBeTrue)
-		So(invalidField.Field, ShouldEqual, "IsSoldout")
+		So(invalidField.Field, ShouldEqual, "is_soldout")
 		So(invalidField.Source, ShouldEqual, "form")
 		So(invalidField.Value, ShouldEqual, "zero")
 	})
@@ -348,7 +348,7 @@ func TestEngine(t *testing.T) {
 		_, err = core.Decode(r)
 		var invalidField *InvalidFieldError
 		So(errors.As(err, &invalidField), ShouldBeTrue)
-		So(invalidField.Field, ShouldEqual, "SortDesc")
+		So(invalidField.Field, ShouldEqual, "sort_desc")
 		So(invalidField.Source, ShouldEqual, "form")
 		So(invalidField.Value, ShouldResemble, []string{"true", "zero", "0"})
 		So(err.Error(), ShouldContainSubstring, "at index 1")

--- a/resolver.go
+++ b/resolver.go
@@ -46,7 +46,7 @@ func (r *fieldResolver) resolve(req *http.Request) (reflect.Value, error) {
 				}
 
 				return rv, &InvalidFieldError{
-					Field:         r.Field.Name,
+					Field:         r.fieldKeys(),
 					Source:        dir.Executor,
 					Value:         gotValue,
 					ErrorMessage:  err.Error(),
@@ -78,6 +78,25 @@ func (r *fieldResolver) resolve(req *http.Request) (reflect.Value, error) {
 	}
 
 	return rv, nil
+}
+
+func (r *fieldResolver) fieldKeys() string {
+	if len(r.Directives) == 0 {
+		return ""
+	}
+
+	if len(r.Directives) <= 1 {
+		return strings.Join(r.Directives[0].Argv, "|")
+	}
+
+	keys := make([]string, 0)
+	for _, d := range r.Directives {
+		for _, a := range d.Argv {
+			keys = append(keys, fmt.Sprintf("%s:%s", d.Executor, a))
+		}
+	}
+
+	return strings.Join(keys, "|")
 }
 
 // buildResolverTree builds a tree of resolvers for the specified struct type.

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -35,3 +35,13 @@ func TestFieldResolver(t *testing.T) {
 		t.Logf("ProductQuery: %s\n", bs)
 	})
 }
+
+func TestResolverWithMissingRequiredField(t *testing.T) {
+	Convey("A resolver with a missing required field", t, func() {
+		resolver, err := buildResolverTree(reflect.TypeOf(ProductQuery{}))
+		r, _ := http.NewRequest("GET", "https://example.com", nil)
+		_, err = resolver.resolve(r)
+		So(err, ShouldNotBeNil)
+		So(err.Error(), ShouldEqual,"invalid field \"created_at\": missing required field")
+	})
+}

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -42,6 +42,6 @@ func TestResolverWithMissingRequiredField(t *testing.T) {
 		r, _ := http.NewRequest("GET", "https://example.com", nil)
 		_, err = resolver.resolve(r)
 		So(err, ShouldNotBeNil)
-		So(err.Error(), ShouldEqual,"invalid field \"created_at\": missing required field")
+		So(err.Error(), ShouldEqual,"invalid field \"form:created_at\": missing required field")
 	})
 }


### PR DESCRIPTION
As per GH-8 this PR updates the resolver error message when a required field is missing to provide the directive keys which can be used to satisfy the constraint without knowing the implementation's golang struct Field names.