### PR TITLE
allow registering custom body decoders, e.g. "json", "xml", "yaml", etc.

### DIFF
--- a/body.go
+++ b/body.go
@@ -18,9 +18,14 @@ const (
 )
 
 type (
+	// JSONBody is the annotation for JSON body.
 	JSONBody struct{}
-	XMLBody  struct{}
 
+	// XMLBody is the annotation for XML body.
+	XMLBody struct{}
+
+	// BodyDecoder decodes the request body into the specified object. Common body types are:
+	// json, xml, yaml, and others.
 	BodyDecoder interface {
 		Decode(src io.Reader, dst interface{}) error
 	}
@@ -49,6 +54,9 @@ func RegisterBodyDecoder(bodyType string, decoder BodyDecoder) {
 }
 
 // ReplaceBodyDecoder replaces or add the body decoder of the specified type.
+// Which is useful when you want to override the default body decoder. For example,
+// the default JSON decoder is borrowed from encoding/json. You can replace it with
+// your own implementation, e.g. json-iterator/go.
 //
 //    func init() {
 //        ReplaceBodyDecoder("json", &myJSONBodyDecoder{})

--- a/body.go
+++ b/body.go
@@ -36,6 +36,11 @@ var (
 	}
 )
 
+// RegisterBodyDecoder registers a new body decoder. Panic if the body type is already registered.
+//
+//    func init() {
+//        RegisterBodyDecoder("yaml", &myYAMLBodyDecoder{})
+//    }
 func RegisterBodyDecoder(bodyType string, decoder BodyDecoder) {
 	if _, ok := bodyDecoders[bodyType]; ok {
 		panic(fmt.Errorf("httpin: %w: %q", ErrDuplicateBodyDecoder, bodyType))
@@ -43,6 +48,11 @@ func RegisterBodyDecoder(bodyType string, decoder BodyDecoder) {
 	ReplaceBodyDecoder(bodyType, decoder)
 }
 
+// ReplaceBodyDecoder replaces or add the body decoder of the specified type.
+//
+//    func init() {
+//        ReplaceBodyDecoder("json", &myJSONBodyDecoder{})
+//    }
 func ReplaceBodyDecoder(bodyType string, decoder BodyDecoder) {
 	if bodyType == "" {
 		panic("httpin: body type cannot be empty")

--- a/decoders.go
+++ b/decoders.go
@@ -34,7 +34,7 @@ func isTypeDecoder(decoder interface{}) bool {
 // RegisterTypeDecoder registers a specific type decoder. Panics on conflicts.
 func RegisterTypeDecoder(typ reflect.Type, decoder interface{}) {
 	if _, ok := decoders[typ]; ok {
-		panic(fmt.Errorf("%w: %q", ErrDuplicateTypeDecoder, typ))
+		panic(fmt.Errorf("httpin: %w: %q", ErrDuplicateTypeDecoder, typ))
 	}
 
 	ReplaceTypeDecoder(typ, decoder)
@@ -43,11 +43,11 @@ func RegisterTypeDecoder(typ reflect.Type, decoder interface{}) {
 // ReplaceTypeDecoder replaces a specific type decoder.
 func ReplaceTypeDecoder(typ reflect.Type, decoder interface{}) {
 	if decoder == nil {
-		panic(fmt.Errorf("%w: %q", ErrNilTypeDecoder, typ))
+		panic(fmt.Errorf("httpin: %w: %q", ErrNilTypeDecoder, typ))
 	}
 
 	if !isTypeDecoder(decoder) {
-		panic(fmt.Errorf("%w: %q", ErrInvalidTypeDecoder, typ))
+		panic(fmt.Errorf("httpin: %w: %q", ErrInvalidTypeDecoder, typ))
 	}
 
 	decoders[typ] = decoder

--- a/directives.go
+++ b/directives.go
@@ -41,7 +41,7 @@ type DirectiveNormalizer interface {
 // taken or nil executor.
 func RegisterDirectiveExecutor(name string, exe DirectiveExecutor, norm DirectiveNormalizer) {
 	if _, ok := executors[name]; ok {
-		panic(fmt.Errorf("%w: %q", ErrDuplicateExecutor, name))
+		panic(fmt.Errorf("httpin: %w: %q", ErrDuplicateExecutor, name))
 	}
 	ReplaceDirectiveExecutor(name, exe, norm)
 }
@@ -50,7 +50,7 @@ func RegisterDirectiveExecutor(name string, exe DirectiveExecutor, norm Directiv
 // on duplicate names.
 func ReplaceDirectiveExecutor(name string, exe DirectiveExecutor, norm DirectiveNormalizer) {
 	if exe == nil {
-		panic(fmt.Errorf("%w: %q", ErrNilExecutor, name))
+		panic(fmt.Errorf("httpin: %w: %q", ErrNilExecutor, name))
 	}
 	executors[name] = exe
 	normalizers[name] = norm

--- a/errors.go
+++ b/errors.go
@@ -20,6 +20,7 @@ var (
 	ErrNilErrorHandler          = errors.New("nil error handler")
 	ErrMaxMemoryTooSmall        = errors.New("max memory too small")
 	ErrNilFile                  = errors.New("nil file")
+	ErrDuplicateBodyDecoder     = errors.New("duplicate body decoder")
 )
 
 type UnsupportedTypeError struct {

--- a/middleware.go
+++ b/middleware.go
@@ -44,7 +44,7 @@ func NewInput(inputStruct interface{}, opts ...Option) middleware {
 
 func ReplaceDefaultErrorHandler(custom ErrorHandler) {
 	if custom == nil {
-		panic(fmt.Errorf("httpin: %v", ErrNilErrorHandler))
+		panic(fmt.Errorf("httpin: %w", ErrNilErrorHandler))
 	}
 	globalCustomErrorHandler = custom
 }


### PR DESCRIPTION
Updates #37 