### PR TITLE
Fix required in nil child struct

### DIFF
--- a/required.go
+++ b/required.go
@@ -6,9 +6,15 @@ package httpin
 // required implements the "required" executor who indicates that the field
 // must be set. If the field value were not set by former executors, error
 // `ErrMissingField` will be returned.
+// If the required field is a member of a child struct that is nil then no
+// error will be returned.
 func required(ctx *DirectiveRuntime) error {
-	if ctx.Context.Value(FieldSet) == nil {
-		return ErrMissingField
+	// check that the containing struct is at root, or is non nil.
+	if ctx.Resolver.Parent.IsRoot() || ctx.Resolver.Parent.Context.Value(FieldSet) != nil {
+		if ctx.Context.Value(FieldSet) == nil {
+			return ErrMissingField
+		}
 	}
+
 	return nil
 }


### PR DESCRIPTION
I believe this to be a regression somewhere between `v0.11.0` and `v0.14.0`.

If you have a nested structure which is parsed using `body=json`, then the `required` tags are being checked for fields of children structs even when they are `nil`.

I believe in this case it makes sense that the `required` flag is not checked as the parent struct is nil.

I've included a test that hopefully makes this clearer.

