### PR TITLE
Upgrade to ggicci/owl 0.4.0 and required go version from 1.19 to 1.20

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.19"
+          go-version: "1.20"
 
       - name: Test and generate coverage report
         run: make test/cover

--- a/directive.go
+++ b/directive.go
@@ -43,7 +43,7 @@ func RegisterDirectiveExecutor(name string, exe DirectiveExecutor) {
 // on duplicate names.
 func ReplaceDirectiveExecutor(name string, exe DirectiveExecutor) {
 	panicOnReservedExecutorName(name)
-	owl.ReplaceDirectiveExecutor(name, exe)
+	owl.RegisterDirectiveExecutor(name, exe, true)
 }
 
 func panicOnReservedExecutorName(name string) {

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/ggicci/httpin
 
-go 1.19
+go 1.20
 
 require (
-	github.com/ggicci/owl v0.1.7
+	github.com/ggicci/owl v0.4.0
 	github.com/go-chi/chi/v5 v5.0.8
 	github.com/gorilla/mux v1.8.0
 	github.com/justinas/alice v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/ggicci/owl v0.1.7 h1:OWdov5RaWxNwbNMoYyeiVV2VFMP9C1XTIMdtgnhncxg=
-github.com/ggicci/owl v0.1.7/go.mod h1:FLuwmWWQC1MnhyDhT9G3/NTOyCMnojzd6oAriRg4Vbw=
+github.com/ggicci/owl v0.4.0 h1:1cwRlynLe6P5ylLyjNWtOP5qVO1bYUmziPYVbOphGHQ=
+github.com/ggicci/owl v0.4.0/go.mod h1:TRPWshRwYej6uES//YW5aNgLB370URwyta1Ytfs7KXs=
 github.com/go-chi/chi/v5 v5.0.8 h1:lD+NLqFcAi1ovnVZpsnObHGW4xb4J8lNmoYVfECH1Y0=
 github.com/go-chi/chi/v5 v5.0.8/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=


### PR DESCRIPTION
Replaces https://github.com/ggicci/httpin/pull/74

- Upgrades ggicci/owl from `v0.1.7` to `v0.4.0` (https://github.com/ggicci/owl/compare/v0.1.7...v0.4.0)
- Upgrades from go `1.19` to `1.20` 
- Switches `owl.ReplaceDirectiveExecutor(name, exe)` to `owl.RegisterDirectiveExecutor(name, exe, true)`