### PR TITLE
fix: move out indirect echo dependency

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,5 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/ggicci/owl v0.8.0 h1:PCueAADCWwuW2jv7fvp40eNjvrv3se/Rhkb+Ah6MPbM=
-github.com/ggicci/owl v0.8.0/go.mod h1:PHRD57u41vFN5UtFz2SF79yTVoM3HlWpjMiE+ZU2dj4=
-github.com/ggicci/owl v0.8.1 h1:vppxAqpNOYBdrPKpcq7lzLy40UmSMr8Oz+h2EsJVgew=
-github.com/ggicci/owl v0.8.1/go.mod h1:PHRD57u41vFN5UtFz2SF79yTVoM3HlWpjMiE+ZU2dj4=
 github.com/ggicci/owl v0.8.2 h1:og+lhqpzSMPDdEB+NJfzoAJARP7qCG3f8uUC3xvGukA=
 github.com/ggicci/owl v0.8.2/go.mod h1:PHRD57u41vFN5UtFz2SF79yTVoM3HlWpjMiE+ZU2dj4=
 github.com/go-chi/chi/v5 v5.0.11 h1:BnpYbFZ3T3S1WMpD79r7R5ThWX40TaFB7L31Y8xqSwA=

--- a/integration/echo_test.go
+++ b/integration/echo_test.go
@@ -1,4 +1,4 @@
-package integration
+package integration_test
 
 import (
 	"fmt"
@@ -8,19 +8,14 @@ import (
 	"testing"
 
 	"github.com/ggicci/httpin"
+	httpin_integration "github.com/ggicci/httpin/integration"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 )
 
-type GetPostOfUserInput struct {
-	Username string `in:"path=username"`
-	PostID   int64  `in:"path=pid"`
-}
-
 func TestUseEchoMux(t *testing.T) {
-
 	e := echo.New()
-	UseEchoPathRouter(e)
+	httpin_integration.UseEchoPathRouter(e)
 
 	req := httptest.NewRequest(http.MethodGet, "/users/ggicci/posts/123", nil)
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)


### PR DESCRIPTION
Make echo's integration test in a separate test package, so we don't need to depend on echo package even indirectly.