### PR TITLE
Add support for `omitempty` field tag to exclude empty values from queries and headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ type ListUsersInput struct {
 	Page     int     `in:"query=page;default=1"`
 	PerPage  int     `in:"query=per_page;default=20"`
 	IsMember bool    `in:"query=is_member"`
-	Search   *string `in:"query=search,omitempty"`
+	Search   *string `in:"query=search;omitempty"`
 }
 
 func ListUsers(rw http.ResponseWriter, r *http.Request) {

--- a/README.md
+++ b/README.md
@@ -52,10 +52,11 @@ Since v0.15.0, httpin also supports creating an HTTP request (`http.Request`) fr
 
 ```go
 type ListUsersInput struct {
-	Token    string `in:"query=access_token;header=x-access-token"`
-	Page     int    `in:"query=page;default=1"`
-	PerPage  int    `in:"query=per_page;default=20"`
-	IsMember bool   `in:"query=is_member"`
+	Token    string  `in:"query=access_token;header=x-access-token"`
+	Page     int     `in:"query=page;default=1"`
+	PerPage  int     `in:"query=per_page;default=20"`
+	IsMember bool    `in:"query=is_member"`
+	Search   *string `in:"query=search,omitempty"`
 }
 
 func ListUsers(rw http.ResponseWriter, r *http.Request) {

--- a/core/directive.go
+++ b/core/directive.go
@@ -17,6 +17,7 @@ func init() {
 	RegisterDirective("default", &DirectiveDefault{})
 	RegisterDirective("nonzero", &DirectiveNonzero{})
 	registerDirective("path", defaultPathDirective)
+	registerDirective("omitempty", &DirectiveOmitEmpty{})
 
 	// decoder is a special executor which does nothing, but is an indicator of
 	// overriding the decoder for a specific field.

--- a/core/formencoder.go
+++ b/core/formencoder.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"github.com/ggicci/httpin/internal"
-	"slices"
 )
 
 type FormEncoder struct {
@@ -10,8 +9,12 @@ type FormEncoder struct {
 }
 
 func (e *FormEncoder) Execute(rtm *DirectiveRuntime) error {
-	if rtm.Value.IsZero() && slices.Contains(rtm.Directive.Argv, "omitempty") {
-		return nil
+	if rtm.Value.IsZero() {
+		for _, d := range rtm.Resolver.Directives {
+			if d.Name == "omitempty" {
+				return nil
+			}
+		}
 	}
 
 	if rtm.IsFieldSet() {

--- a/core/formencoder.go
+++ b/core/formencoder.go
@@ -1,12 +1,20 @@
 package core
 
-import "github.com/ggicci/httpin/internal"
+import (
+	"github.com/ggicci/httpin/internal"
+	"strings"
+)
 
 type FormEncoder struct {
 	Setter func(key string, value []string) // form value setter
 }
 
 func (e *FormEncoder) Execute(rtm *DirectiveRuntime) error {
+	tag := rtm.Resolver.Field.Tag.Get("in")
+	if rtm.Value.IsZero() && strings.Contains(tag, "omitempty") {
+		return nil
+	}
+
 	if rtm.IsFieldSet() {
 		return nil // skip when already encoded by former directives
 	}

--- a/core/formencoder.go
+++ b/core/formencoder.go
@@ -10,10 +10,8 @@ type FormEncoder struct {
 
 func (e *FormEncoder) Execute(rtm *DirectiveRuntime) error {
 	if rtm.Value.IsZero() {
-		for _, d := range rtm.Resolver.Directives {
-			if d.Name == "omitempty" {
-				return nil
-			}
+		if rtm.Resolver.GetDirective("omitempty") != nil {
+			return nil
 		}
 	}
 

--- a/core/formencoder.go
+++ b/core/formencoder.go
@@ -2,7 +2,7 @@ package core
 
 import (
 	"github.com/ggicci/httpin/internal"
-	"strings"
+	"slices"
 )
 
 type FormEncoder struct {
@@ -10,8 +10,7 @@ type FormEncoder struct {
 }
 
 func (e *FormEncoder) Execute(rtm *DirectiveRuntime) error {
-	tag := rtm.Resolver.Field.Tag.Get("in")
-	if rtm.Value.IsZero() && strings.Contains(tag, "omitempty") {
+	if rtm.Value.IsZero() && slices.Contains(rtm.Directive.Argv, "omitempty") {
 		return nil
 	}
 

--- a/core/header_test.go
+++ b/core/header_test.go
@@ -29,7 +29,7 @@ func TestDirectiveHeader_Decode(t *testing.T) {
 
 func TestDirectiveHeader_NewRequest(t *testing.T) {
 	type ApiQuery struct {
-		ApiUid   int     `in:"header=x-api-uid"`
+		ApiUid   int     `in:"header=x-api-uid,omitempty"`
 		ApiToken *string `in:"header=X-Api-Token,omitempty"`
 	}
 
@@ -54,7 +54,7 @@ func TestDirectiveHeader_NewRequest(t *testing.T) {
 
 	t.Run("with empty value", func(t *testing.T) {
 		query := &ApiQuery{
-			ApiUid:   91241844,
+			ApiUid:   0,
 			ApiToken: nil,
 		}
 
@@ -64,10 +64,12 @@ func TestDirectiveHeader_NewRequest(t *testing.T) {
 		assert.NoError(t, err)
 
 		expected, _ := http.NewRequest("POST", "/api", nil)
-		expected.Header.Set("x-api-uid", "91241844")
 		assert.Equal(t, expected, req)
 
-		_, ok := req.Header["X-Api-Token"]
+		_, ok := req.Header["X-Api-Uid"]
+		assert.False(t, ok)
+
+		_, ok = req.Header["X-Api-Token"]
 		assert.False(t, ok)
 	})
 }

--- a/core/header_test.go
+++ b/core/header_test.go
@@ -52,7 +52,7 @@ func TestDirectiveHeader_NewRequest(t *testing.T) {
 		assert.Equal(t, expected, req)
 	})
 
-	t.Run("with nil value", func(t *testing.T) {
+	t.Run("with empty value", func(t *testing.T) {
 		query := &ApiQuery{
 			ApiUid:   91241844,
 			ApiToken: nil,

--- a/core/header_test.go
+++ b/core/header_test.go
@@ -29,8 +29,8 @@ func TestDirectiveHeader_Decode(t *testing.T) {
 
 func TestDirectiveHeader_NewRequest(t *testing.T) {
 	type ApiQuery struct {
-		ApiUid   int     `in:"header=x-api-uid,omitempty"`
-		ApiToken *string `in:"header=X-Api-Token,omitempty"`
+		ApiUid   int     `in:"header=x-api-uid;omitempty"`
+		ApiToken *string `in:"header=X-Api-Token;omitempty"`
 	}
 
 	t.Run("with all values", func(t *testing.T) {

--- a/core/omitempty.go
+++ b/core/omitempty.go
@@ -1,0 +1,17 @@
+// directive: "omitempty"
+// https://ggicci.github.io/httpin/directives/omitempty
+
+package core
+
+// DirectiveOmitEmpty is used with the DirectiveQuery, DirectiveForm, and DirectiveHeader to indicate that the field
+// should be omitted when the value is empty.
+// It does not have any affect when used by itself
+type DirectiveOmitEmpty struct{}
+
+func (*DirectiveOmitEmpty) Decode(_ *DirectiveRuntime) error {
+	return nil
+}
+
+func (*DirectiveOmitEmpty) Encode(_ *DirectiveRuntime) error {
+	return nil
+}

--- a/core/query_test.go
+++ b/core/query_test.go
@@ -40,43 +40,61 @@ func TestDirectiveQuery_NewRequest(t *testing.T) {
 		NameList []string `in:"query=name_list[]"`
 		AgeList  []int    `in:"query=age_list[]"`
 
-		NamePointer *string `in:"query=name_pointer"`
-		AgePointer  *int    `in:"query=age_pointer"`
-	}
-	query := &SearchQuery{
-		Name:     "cupcake",
-		Age:      12,
-		Enabled:  true,
-		Price:    6.28,
-		NameList: []string{"apple", "banana", "cherry"},
-		AgeList:  []int{1, 2, 3},
-		NamePointer: func() *string {
-			s := "pointer cupcake"
-			return &s
-		}(),
-		AgePointer: func() *int {
-			i := 19
-			return &i
-		}(),
+		NamePointer *string `in:"query=name_pointer,omitempty"`
+		AgePointer  *int    `in:"query=age_pointer,omitempty"`
 	}
 
-	co, err := New(SearchQuery{})
-	assert.NoError(t, err)
-	req, err := co.NewRequest("GET", "/pets", query)
-	assert.NoError(t, err)
+	t.Run("with all values", func(t *testing.T) {
+		query := &SearchQuery{
+			Name:     "cupcake",
+			Age:      12,
+			Enabled:  true,
+			Price:    6.28,
+			NameList: []string{"apple", "banana", "cherry"},
+			AgeList:  []int{1, 2, 3},
+			NamePointer: func() *string {
+				s := "pointer cupcake"
+				return &s
+			}(),
+			AgePointer: func() *int {
+				i := 19
+				return &i
+			}(),
+		}
 
-	expected, _ := http.NewRequest("GET", "/pets", nil)
-	expectedQuery := make(url.Values)
-	expectedQuery.Set("name", query.Name)                 // query.Name
-	expectedQuery.Set("age", "12")                        // query.Age
-	expectedQuery.Set("enabled", "true")                  // query.Enabled
-	expectedQuery.Set("price", "6.28")                    // query.Price
-	expectedQuery["name_list[]"] = query.NameList         // query.NameList
-	expectedQuery["age_list[]"] = []string{"1", "2", "3"} // query.AgeList
-	expectedQuery.Set("name_pointer", *query.NamePointer) // query.NamePointer
-	expectedQuery.Set("age_pointer", "19")                // query.PointerAge
-	expected.URL.RawQuery = expectedQuery.Encode()
-	assert.Equal(t, expected, req)
+		co, err := New(SearchQuery{})
+		assert.NoError(t, err)
+		req, err := co.NewRequest("GET", "/pets", query)
+		assert.NoError(t, err)
+
+		expected, _ := http.NewRequest("GET", "/pets", nil)
+		expectedQuery := make(url.Values)
+		expectedQuery.Set("name", query.Name)                 // query.Name
+		expectedQuery.Set("age", "12")                        // query.Age
+		expectedQuery.Set("enabled", "true")                  // query.Enabled
+		expectedQuery.Set("price", "6.28")                    // query.Price
+		expectedQuery["name_list[]"] = query.NameList         // query.NameList
+		expectedQuery["age_list[]"] = []string{"1", "2", "3"} // query.AgeList
+		expectedQuery.Set("name_pointer", *query.NamePointer) // query.NamePointer
+		expectedQuery.Set("age_pointer", "19")                // query.PointerAge
+		expected.URL.RawQuery = expectedQuery.Encode()
+		assert.Equal(t, expected, req)
+	})
+
+	t.Run("with nil values", func(t *testing.T) {
+		query := &SearchQuery{}
+
+		co, err := New(SearchQuery{})
+		assert.NoError(t, err)
+		req, err := co.NewRequest("GET", "/pets", query)
+		assert.NoError(t, err)
+
+		assert.True(t, req.URL.Query().Has("name"))
+		assert.True(t, req.URL.Query().Has("age"))
+
+		assert.False(t, req.URL.Query().Has("name_pointer"))
+		assert.False(t, req.URL.Query().Has("age_pointer"))
+	})
 }
 
 type Location struct {

--- a/core/query_test.go
+++ b/core/query_test.go
@@ -33,14 +33,14 @@ func TestDirectiveQuery_Decode(t *testing.T) {
 func TestDirectiveQuery_NewRequest(t *testing.T) {
 	type SearchQuery struct {
 		Name    string  `in:"query=name"`
-		Age     int     `in:"query=age"`
+		Age     int     `in:"query=age,omitempty"`
 		Enabled bool    `in:"query=enabled"`
 		Price   float64 `in:"query=price"`
 
 		NameList []string `in:"query=name_list[]"`
 		AgeList  []int    `in:"query=age_list[]"`
 
-		NamePointer *string `in:"query=name_pointer,omitempty"`
+		NamePointer *string `in:"query=name_pointer"`
 		AgePointer  *int    `in:"query=age_pointer,omitempty"`
 	}
 
@@ -81,7 +81,7 @@ func TestDirectiveQuery_NewRequest(t *testing.T) {
 		assert.Equal(t, expected, req)
 	})
 
-	t.Run("with nil values", func(t *testing.T) {
+	t.Run("with empty values", func(t *testing.T) {
 		query := &SearchQuery{}
 
 		co, err := New(SearchQuery{})
@@ -90,9 +90,9 @@ func TestDirectiveQuery_NewRequest(t *testing.T) {
 		assert.NoError(t, err)
 
 		assert.True(t, req.URL.Query().Has("name"))
-		assert.True(t, req.URL.Query().Has("age"))
+		assert.False(t, req.URL.Query().Has("age"))
 
-		assert.False(t, req.URL.Query().Has("name_pointer"))
+		assert.True(t, req.URL.Query().Has("name_pointer"))
 		assert.False(t, req.URL.Query().Has("age_pointer"))
 	})
 }

--- a/core/query_test.go
+++ b/core/query_test.go
@@ -33,7 +33,7 @@ func TestDirectiveQuery_Decode(t *testing.T) {
 func TestDirectiveQuery_NewRequest(t *testing.T) {
 	type SearchQuery struct {
 		Name    string  `in:"query=name"`
-		Age     int     `in:"query=age,omitempty"`
+		Age     int     `in:"query=age;omitempty"`
 		Enabled bool    `in:"query=enabled"`
 		Price   float64 `in:"query=price"`
 
@@ -41,7 +41,7 @@ func TestDirectiveQuery_NewRequest(t *testing.T) {
 		AgeList  []int    `in:"query=age_list[]"`
 
 		NamePointer *string `in:"query=name_pointer"`
-		AgePointer  *int    `in:"query=age_pointer,omitempty"`
+		AgePointer  *int    `in:"query=age_pointer;omitempty"`
 	}
 
 	t.Run("with all values", func(t *testing.T) {


### PR DESCRIPTION
Adds support for an `omitempty` tag.

Main use case is for query parameters where we may not want have empty keys

i.e. `/pets?name_pointer=`

By adding `omitempty` to the tag then this the key will not appear in the query string

i.e.
```
	type SearchQuery struct {
		NamePointer *string `in:"query=name_pointer,omitempty"`
	}
```
This will create `/pets`

This has been added to the `formencoder` so that it will also remove empty headers.

I have picked `omitempty` as I feel this will feel most natural for engineers as they are likely already used to this syntax with JSON.