### PR TITLE
feat: integrate with Go native http lib to extract path variables

### DIFF
--- a/integration/echo.go
+++ b/integration/echo.go
@@ -18,10 +18,6 @@ import (
 //	func init() {
 //	    e := echo.New()
 //	    httpin_integration.UseEchoRouter("path", e)
-//
-// // or
-//
-//	    httpin_integration.UseEchoPathRouter(e)
 //	}
 func UseEchoRouter(name string, e *echo.Echo) {
 	core.RegisterDirective(
@@ -29,10 +25,6 @@ func UseEchoRouter(name string, e *echo.Echo) {
 		core.NewDirectivePath((&echoRouterExtractor{e}).Execute),
 		true,
 	)
-}
-
-func UseEchoPathRouter(e *echo.Echo) {
-	UseEchoRouter("path", e)
 }
 
 // echoRouterExtractor is an extractor for mux.Vars

--- a/integration/echo_test.go
+++ b/integration/echo_test.go
@@ -15,7 +15,9 @@ import (
 
 func TestUseEchoMux(t *testing.T) {
 	e := echo.New()
-	httpin_integration.UseEchoPathRouter(e)
+	// NOTE: I removed the API UseEchoPathRouter because it introduces minimal benefit
+	// but adds surface area and maintenance cost.
+	httpin_integration.UseEchoRouter("path", e)
 
 	req := httptest.NewRequest(http.MethodGet, "/users/ggicci/posts/123", nil)
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)

--- a/integration/http.go
+++ b/integration/http.go
@@ -1,14 +1,25 @@
 package integration
 
 import (
-	"github.com/ggicci/httpin/core"
 	"mime/multipart"
 	"net/http"
+
+	"github.com/ggicci/httpin/core"
 )
 
 type HttpMuxVarsFunc func(*http.Request) map[string]string
 
-func UseHttpMux(name string) {
+// UseHttpPathVariable registers a new directive executor which can extract
+// values from URL path variables via `http.Request.PathValue` API.
+// https://ggicci.github.io/httpin/integrations/http
+//
+// Usage:
+//
+//	import httpin_integration "github.com/ggicci/httpin/integration"
+//	func init() {
+//		httpin_integration.UseHttpPathVariable("path")
+//	}
+func UseHttpPathVariable(name string) {
 	core.RegisterDirective(
 		name,
 		core.NewDirectivePath((&httpMuxVarsExtractor{}).Execute),
@@ -16,13 +27,7 @@ func UseHttpMux(name string) {
 	)
 }
 
-func UseHttpPathMux() {
-	UseHttpMux("path")
-}
-
-type httpMuxVarsExtractor struct {
-	Vars http.ServeMux
-}
+type httpMuxVarsExtractor struct{}
 
 func (mux *httpMuxVarsExtractor) Execute(rtm *core.DirectiveRuntime) error {
 	req := rtm.GetRequest()

--- a/integration/http_test.go
+++ b/integration/http_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/ggicci/httpin"
-	httpinIntegration "github.com/ggicci/httpin/integration"
+	httpin_integration "github.com/ggicci/httpin/integration"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -19,7 +19,7 @@ type HttpMuxPathInput struct {
 }
 
 func TestUseHttpMux(t *testing.T) {
-	httpinIntegration.UseHttpMux("path")
+	httpin_integration.UseHttpPathVariable("path")
 
 	srv := http.NewServeMux()
 	srv.HandleFunc("/users/{username}/posts/{pid}", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
- Rename APIs to align naming conventions with other integrations
- Eliminate APIs, which brings minimal benefit